### PR TITLE
Add pinhole-equidistant translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 1. Calibrate the cameras by following this [tutorial](https://github.com/ethz-asl/kalibr/wiki/calibrating-the-vi-sensor)
 
 2. Install kalibr2vins
+    - Uses [python3-poetry](https://python-poetry.org/)
+    - `cd kalibr2vins; poetry install`
+    - Run commands in poetry shell.
 
 3. run `kalibr2vins --cameras-conf dataset-camchain-imucam.yaml --imu-conf dataset-imu.yaml`
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@
 3. run `kalibr2vins --cameras-conf dataset-camchain-imucam.yaml --imu-conf dataset-imu.yaml`
 
 4. run vins-fusion with generated configuration
+    - Configs are generated in `kalibr2vins/vins_config/`

--- a/kalibr2vins/cameras_templates.py
+++ b/kalibr2vins/cameras_templates.py
@@ -37,8 +37,27 @@ projection_parameters:
    u0: {intrinsics[3]}
    v0: {intrinsics[4]}
 """
+KANNALA_BRANDT = """%YAML:1.0
+---
+model_type: KANNALA_BRANDT
+camera_name: {name}
+image_width: {resolution[0]}
+image_height: {resolution[1]}
 
+distortion_parameters:
+   # Note that EquidistantCamera uses 'k_N+1' to describe 'k_N' in the Kalibr wiki's equidistant implementation
+   k2: {distortion_coeffs[0]}
+   k3: {distortion_coeffs[1]}
+   k4: {distortion_coeffs[2]}
+   k5: {distortion_coeffs[3]}
+projection_parameters:
+   mu: {intrinsics[0]}
+   mv: {intrinsics[1]}
+   u0: {intrinsics[2]}
+   v0: {intrinsics[3]}
+"""
 TEMPLATES = {
     'pinhole-radtan': PINHOLE_RADTAN,
     'omni-radtan': OMNI_RADTAN,
+    'pinhole-equidistant': KANNALA_BRANDT,
 }


### PR DESCRIPTION
- Equidistant (KANNALA_BRANDT) model was not supported
- Add in the YAML translation file for the KANNALA_BRANDT model. 

I am far from calibration expert, but here is why I think this translation is correct:
-  Distortion params:
   - For [VINS-Fusion](https://github.com/hengli/camodocal/blob/master/include/camodocal/camera_models/EquidistantCamera.h#L160-L168
): `theta(1 + k2*theta^2 + k3*theta^4 + k4*theta^6 + k5*theta^8)`
- [Kalibr](https://github.com/ethz-asl/kalibr/wiki/supported-models) links to [OpenCV doc](https://docs.opencv.org/3.4/db/d58/group__calib3d__fisheye.html#details)
   - `theta(1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)`
   - Therefore, VINS nomenclature : k_{n+1} corresponds with opencv k_{n}

- Projection params:
   -  [VINS](https://github.com/hengli/camodocal/blob/master/include/camodocal/camera_models/EquidistantCamera.h#L209-L210)
      -  Same as [pinhole model](https://github.com/hengli/camodocal/blob/master/include/camodocal/camera_models/PinholeCamera.h#L190-L191) where alpha is 0, with nomenclature mu, mv, u0, v0
   - [Kalibr](https://github.com/ethz-asl/kalibr/wiki/supported-models): Uses pinhole parameters fx, fy, cx, cy